### PR TITLE
Pass down download_models

### DIFF
--- a/R/txt2img_sd21.R
+++ b/R/txt2img_sd21.R
@@ -46,7 +46,8 @@ txt2img_sd21 <- function(prompt,
                          ...) {
   model_name = "sd21"
   m2d <- models2devices(model_name = model_name, devices = devices,
-                        unet_dtype_str = unet_dtype_str)
+                        unet_dtype_str = unet_dtype_str,
+                        download_models = download_models)
   model_dir <- m2d$model_dir
   model_files <- m2d$model_files
   devices <- m2d$devices

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ You can install the development version of diffuseR from GitHub:
 
 ```r
 # install.packages("devtools")
-devtools::install_github("yourusername/diffuseR")
+devtools::install_github("cornball-ai/diffuseR")
 # Or
 # install.packages("targets")
-targets::install_github("yourusername/diffuseR")
+targets::install_github("cornball-ai/diffuseR")
 ```
 
 ## Features
@@ -74,7 +74,7 @@ torch::local_no_grad()
 cat_img <- txt2img(
   prompt = "a photorealistic cat wearing sunglasses",
   model = "sd21", # Specify the model to use, e.g., "sd21" for Stable Diffusion 2.1
-  download_model = TRUE # Automatically download the model if not already present
+  download_models = TRUE, # Automatically download the model if not already present
   steps = 30,
   save_to = "cat.png",
 )


### PR DESCRIPTION
Also tweak a related portion of the README to make the parameter name match and update the github_install commands to refer to the specific repo.

Note: I haven't been fully able to run the model due to running into issues with downloading files, including a potentially missing model file (for the "encoder" portion).