### PR TITLE
Add GitHub Actions CI with r-ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,39 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  _R_CHECK_FORCE_SUGGESTS_: "false"
+  TORCH_HOME: /tmp/torch
+
+jobs:
+  ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {os: macos-latest}
+          - {os: ubuntu-latest}
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup
+        uses: eddelbuettel/github-actions/r-ci@master
+
+      - name: Dependencies
+        run: ./run.sh install_all
+
+      - name: Install torch
+        run: |
+          mkdir -p $TORCH_HOME
+          Rscript -e 'torch::install_torch()'
+
+      - name: Test
+        run: ./run.sh run_tests


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yaml` using eddelbuettel/r-ci
- Runs on Ubuntu and macOS
- Installs deps and runs tests via r-ci

## Test plan
- [ ] CI workflow runs successfully on push
- [ ] Both Ubuntu and macOS jobs pass