### PR TITLE
Load VAE encoder in img2img pipeline

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: diffuseR
 Title: Functional Interface to Diffusion Models in R
-Version: 0.0.1
+Version: 0.0.2
 Authors@R: 
     person("Troy", "Hernandez", email = "troy@cornball.ai", role = c("aut", "cre"))
 Description: A native R implementation of diffusion models providing a functional 

--- a/R/img2img.R
+++ b/R/img2img.R
@@ -60,6 +60,7 @@ img2img <- function (input_image, prompt, negative_prompt = NULL,
 
     if (is.null(pipeline)) {
         pipeline <- load_pipeline(model_name = model_name, m2d = m2d,
+            i2i = TRUE,
             unet_dtype_str = unet_dtype_str,
             use_native_decoder = use_native_decoder,
             use_native_text_encoder = use_native_text_encoder,


### PR DESCRIPTION
## Summary
- `img2img()` called `load_pipeline()` without `i2i = TRUE`, so the VAE encoder was never loaded and `pipeline$encoder(image_tensor)` died with `attempt to apply non-function`.
- One-line fix: pass `i2i = TRUE` so `load_pipeline()` loads the encoder component.
- Bumps version to 0.0.2.

## Test plan
- [x] Reproduced original error on Blackwell with `model_name = "sdxl"`, `use_native_*` flags
- [x] After fix: img2img completes end-to-end, produces output PNG