### PR TITLE
Apply the allocator gc-gate fix to SD21/SDXL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: diffuseR
 Title: Functional Interface to Diffusion Models in R
-Version: 0.1.0.3
+Version: 0.1.0.4
 Authors@R: c(
     person("Troy", "Hernandez", email = "troy@cornball.ai", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0005-4248-604X")),

--- a/R/load_pipeline.R
+++ b/R/load_pipeline.R
@@ -35,6 +35,17 @@ load_pipeline <- function(model_name, m2d, i2i = FALSE, unet_dtype_str,
     device_cpu <- m2d$device_cpu
     device_cuda <- m2d$device_cuda
 
+    if (any(unlist(devices) == "cuda")) {
+        # Same chronic-allocator-gate fix as the FLUX/Z-Image pipelines
+        # (see .flux_gc_gates). Measured at 50 steps (native modules,
+        # decoder on CPU, RTX 5060 Ti 16 GB), warm generation:
+        # SDXL 1024^2 234 -> 100 s (gc 209 -> 75 s); SD 2.1 768^2
+        # 101 -> 26 s (gc 88 -> 15 s). Note the reduced gc cadence lets
+        # the garbage sawtooth ride higher (SD21 peak 5.4 -> 13.3 GB);
+        # cards much smaller than 16 GB may need different gate sizing.
+        .flux_gc_gates(footprint_gb = 12)
+    }
+
     pipeline <- list()
     # Load models into the environment
     if (i2i) {


### PR DESCRIPTION
Stacked on #24 (needs `.flux_gc_gates()` from that branch; will retarget
to main when #24 merges).

`load_pipeline()` now routes through the same allocator gc-gate fix as
the FLUX/Z-Image pipelines whenever any component sits on CUDA. The
legacy SD path had the identical pathology: the torch allocated/reserved
ratio gate is chronically exceeded under backend:native, so R gc fired
on nearly every CUDA allocation.

Measured at 50 steps, warm generation (native modules, decoder on CPU,
RTX 5060 Ti 16 GB):

| Model | Before | After | R gc share |
|---|---|---|---|
| SDXL 1024x1024 | 234 s | **100 s** | 209 s -> 75 s |
| SD 2.1 768x768 | 101 s | **26 s** | 88 s -> 15 s |

Notes:

- The reduced gc cadence lets the garbage sawtooth ride higher between
  collections (SD21 peak 5.4 -> 13.3 GB alloc on the 16 GB card). The
  gate constants are tuned for 16 GB; smaller cards may need different
  sizing — measurement tracked separately.
- The all-GPU SDXL layout at 1024px peaks ~14 GB with native modules
  and can OOM on 16 GB regardless of gates (decoder was on CPU for
  these measurements). Pre-existing, not changed here.
- README's SDXL/FLUX.2 comparison table numbers were measured under a
  different (undocumented) component layout and are not restated here.

Full suite 692/692.

🤖 Generated with [Claude Code](https://claude.com/claude-code)