### PR TITLE
Use fused SDPA for LTX-2.3 attention

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,13 +20,20 @@
   sub-2 GB diffusers shards plus an index, so large fp16 weights load on
   stock CRAN safetensors.
 * `download_sdxl()` fetches the SDXL diffusers weights from the
-  `cornball-ai/sdxl-R` dataset (hosting in progress).
+  `cornball-ai/sdxl-R` dataset.
+
+## LTX-2.3 loading and attention
+
 * Checkpoint loaders build module skeletons (uninitialized weights at
   the target dtype) instead of initializing full-precision modules and
   casting: the LTX-2.3 NF4 pipeline load drops from ~108 GB host RAM
   (kernel OOM on a 125 GB machine) to ~21 GB, and Gemma3 from ~72 GB of
   transient writes to its resident size. `load_gemma3_text_encoder()`
   now errors on any parameter the checkpoint does not fill.
+* LTX-2.3 attention now uses R torch fused scaled-dot-product attention
+  when available and no explicit query chunk is requested. The adaptive
+  chunked/scratch-buffer implementation remains the fallback for older
+  torch builds, explicit `attn_chunk`, or `options(diffuseR.ltx23_fused_sdpa = FALSE)`.
 
 # diffuseR 0.1.0.6 (development)
 

--- a/R/dit_ltx23_modules.R
+++ b/R/dit_ltx23_modules.R
@@ -170,12 +170,12 @@ ltx23_ada_layer_norm_single <- torch::nn_module(
     buf
 }
 
-# Scaled dot-product attention on [B, H, S, D] tensors. R torch has no
-# fused SDPA, so the [B, H, Sq, Sk] score matrix materializes; queries
-# are chunked adaptively against a memory budget and all large
-# temporaries live in reusable scratch buffers.
-.ltx23_sdpa <- function(query, key, value, attention_mask = NULL,
-                        chunk_size = NULL) {
+# Manual scaled dot-product attention on [B, H, S, D] tensors. The
+# [B, H, Sq, Sk] score matrix materializes, so queries are chunked
+# adaptively against a memory budget and all large temporaries live in
+# reusable scratch buffers.
+.ltx23_sdpa_manual <- function(query, key, value, attention_mask = NULL,
+    chunk_size = NULL) {
     head_dim <- query$shape[length(query$shape)]
     scale <- 1.0 / sqrt(head_dim)
     key_t <- key$transpose(-2L, -1L)
@@ -268,6 +268,52 @@ ltx23_ada_layer_norm_single <- torch::nn_module(
         start <- start + len
     }
     out_buf
+}
+
+# Resolve the exported fused SDPA binding once. torch 0.17.0 ships this,
+# but capability-based lookup preserves compatibility with older builds.
+.ltx23_fused_sdpa_fn <- local({
+    fn <- NULL
+    resolved <- FALSE
+    function() {
+        if (!resolved) {
+            if ("torch_scaled_dot_product_attention" %in%
+                    getNamespaceExports("torch")) {
+                fn <<- getExportedValue(
+                    "torch", "torch_scaled_dot_product_attention"
+                )
+            }
+            resolved <<- TRUE
+        }
+        fn
+    }
+})
+
+.ltx23_fused_sdpa <- function(query, key, value, attention_mask = NULL) {
+    fn <- .ltx23_fused_sdpa_fn()
+    if (is.null(fn)) {
+        stop("Fused scaled-dot-product attention is unavailable.",
+             call. = FALSE)
+    }
+    if (is.null(attention_mask)) {
+        fn(query, key, value, dropout_p = 0, is_causal = FALSE)
+    } else {
+        fn(query, key, value, attn_mask = attention_mask,
+           dropout_p = 0, is_causal = FALSE)
+    }
+}
+
+# Prefer native fused SDPA when no explicit query chunk was requested. Set
+# options(diffuseR.ltx23_fused_sdpa = FALSE) to force the manual fallback.
+.ltx23_sdpa <- function(query, key, value, attention_mask = NULL,
+                        chunk_size = NULL) {
+    use_fused <- is.null(chunk_size) &&
+        isTRUE(getOption("diffuseR.ltx23_fused_sdpa", TRUE)) &&
+        !is.null(.ltx23_fused_sdpa_fn())
+    if (use_fused) {
+        return(.ltx23_fused_sdpa(query, key, value, attention_mask))
+    }
+    .ltx23_sdpa_manual(query, key, value, attention_mask, chunk_size)
 }
 
 #' Release the attention scratch buffers

--- a/inst/tinytest/test_dit_ltx23.R
+++ b/inst/tinytest/test_dit_ltx23.R
@@ -64,6 +64,43 @@ output_buf$fill_(2)
 score_buf$add_(1)
 expect_equal(as.numeric(output_buf$mean()), 2)
 release_attn_buffers()
+# --- Fused SDPA matches the chunked manual fallback ---------------------------
+sdpa <- diffuseR:::.ltx23_sdpa
+sdpa_manual <- diffuseR:::.ltx23_sdpa_manual
+fused_sdpa <- diffuseR:::.ltx23_fused_sdpa
+fused_sdpa_fn <- diffuseR:::.ltx23_fused_sdpa_fn
+attn_scratch <- get(".ltx23_attn_scratch", envir = asNamespace("diffuseR"))
+
+torch::torch_manual_seed(23)
+q <- torch::torch_randn(c(1L, 2L, 5L, 8L))
+k <- torch::torch_randn(c(1L, 2L, 7L, 8L))
+v <- torch::torch_randn(c(1L, 2L, 7L, 6L))
+mask <- torch::torch_zeros(c(1L, 1L, 5L, 7L))
+mask[, , , 7] <- -10000
+
+manual_mask <- sdpa_manual(q, k, v, mask, chunk_size = 2L)$clone()
+manual_nomask <- sdpa_manual(q, k, v, chunk_size = 2L)$clone()
+if (!is.null(fused_sdpa_fn())) {
+  release_attn_buffers()
+  fused_mask <- fused_sdpa(q, k, v, mask)
+  fused_nomask <- fused_sdpa(q, k, v)
+  expect_true(max_abs_diff(fused_mask, manual_mask) < 1e-5)
+  expect_true(max_abs_diff(fused_nomask, manual_nomask) < 1e-5)
+
+  old <- options(diffuseR.ltx23_fused_sdpa = TRUE)
+  auto_mask <- sdpa(q, k, v, mask)
+  options(old)
+  expect_true(max_abs_diff(auto_mask, fused_mask) < 1e-6)
+  expect_equal(length(ls(attn_scratch)), 0L)
+}
+
+release_attn_buffers()
+old <- options(diffuseR.ltx23_fused_sdpa = FALSE)
+fallback_mask <- sdpa(q, k, v, mask)$clone()
+options(old)
+expect_true(max_abs_diff(fallback_mask, manual_mask) < 1e-5)
+expect_true(length(ls(attn_scratch)) > 0L)
+release_attn_buffers()
 
 # --- Gated attention with split RoPE ------------------------------------------
 


### PR DESCRIPTION
## Summary

- Use the standard R torch 0.17 exported scaled-dot-product attention binding for LTX-2.3 when available.
- Preserve the adaptive chunked scratch-buffer implementation for older torch builds, explicit attn_chunk requests, and options(diffuseR.ltx23_fused_sdpa = FALSE).
- Add direct masked and unmasked fused/manual parity tests, backend-selection checks, and keep the full tiny DiT fixture on the default fused path.

## Benchmark

CUDA BF16 at shape [1, 16, 8192, 64]:

- fused: 0.0060 s/iteration
- manual adaptive chunking: 0.0307 s/iteration
- speedup: 5.11x
- max absolute difference: 0.00146484

## Validation

- Focused LTX DiT suite: 32 results, all green.
- Full diffuseR tinytest suite: green after a confirmed fresh install/reload.
- Patch hygiene and source parsing checks: green.