### PR TITLE
Build the Qwen3 attention mask in the query dtype

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: diffuseR
 Title: Functional Interface to Diffusion Models in R
-Version: 0.1.0.7
+Version: 0.1.0.8
 Authors@R: c(
     person("Troy", "Hernandez", email = "troy@cornball.ai", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0005-4248-604X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# diffuseR 0.1.0.8 (development)
+
+* The Qwen3 encoder builds its additive attention mask in the query
+  dtype, fixing the "invalid dtype for bias" CUDA error every FLUX.2
+  prompt encode hit through the fused SDPA path (since #33).
+
 # diffuseR 0.1.0.7 (development)
 
 ## SDXL native pipeline from safetensors

--- a/R/qwen3_text_encoder.R
+++ b/R/qwen3_text_encoder.R
@@ -164,17 +164,22 @@ qwen3_encoder <- torch::nn_module(
     b <- input_ids$shape[1]
     s <- input_ids$shape[2]
     device <- x$device
-    f32 <- torch::torch_float32()
+    dt <- x$dtype
 
     rope <- .qwen3_rope_tables(s, self$head_dim, self$rope_theta, device)
 
-    # Additive causal (+ padding) mask [B, 1, S, S] in float32
-    neg <- -3.4e38
-    causal <- torch::torch_full(c(s, s), neg, dtype = f32,
+    # Additive causal (+ padding) mask [B, 1, S, S] in the compute dtype:
+    # the fused SDPA kernel requires the bias dtype to match the query.
+    # -10000 (the dit_ltx23 convention) stays finite in every float
+    # dtype, including where -3.4e38 would overflow bfloat16 to -Inf.
+    # The $neg()$add(1) chain (not `1 - x`) keeps torch Scalars, since
+    # the Ops dispatch materializes R scalars as Float and promotes.
+    neg <- -10000
+    causal <- torch::torch_full(c(s, s), neg, dtype = dt,
                                 device = device)$triu(diagonal = 1L)
     mask <- causal$unsqueeze(1L)$unsqueeze(1L)$expand(c(b, 1L, s, s))
     if (!is.null(attention_mask)) {
-        pad <- (1 - attention_mask$to(dtype = f32, device = device))$mul(neg)
+        pad <- attention_mask$to(dtype = dt, device = device)$neg()$add(1)$mul(neg)
         mask <- mask + pad$unsqueeze(2L)$unsqueeze(2L)
     }
 


### PR DESCRIPTION
Every FLUX.2 prompt encode on CUDA failed with "invalid dtype for bias - should match query's dtype" since #33 routed the Qwen3 encoder's additive mask through the fused SDPA kernel, whose memory-efficient backend requires the bias dtype to match the query. The mask was always float32 against bf16 q/k/v.

The mask is now built in the embedding dtype. Two adjacent traps handled along the way:

- The old -3.4e38 fill overflows bfloat16 to -Inf; the mask now uses -10000, the same convention as the LTX-2.3 transformer masks.
- R torch's `1 - tensor` Ops dispatch materializes the scalar as a dimensioned Float tensor and promotes bf16 back to f32, so the pad term uses the `$neg()$add(1)$mul()` chain instead (upstream fix proposed in mlverse/torch#1471).

Verified with a kernel-level repro and a small-config encoder forward: CUDA bf16 and CPU f32 both pass with finite outputs. The LTX-2.3 transformer already casts its masks to the hidden-state dtype, so the stv path was unaffected.