### PR TITLE
Add a "progress" verbosity level to the denoise loops

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: diffuseR
 Title: Functional Interface to Diffusion Models in R
-Version: 0.1.0.9
+Version: 0.1.0.10
 Authors@R: c(
     person("Troy", "Hernandez", email = "troy@cornball.ai", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0005-4248-604X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# diffuseR 0.1.0.10 (development)
+
+* The generators accept a three-level `verbose`: "silent", "progress",
+  "steps" (logicals still work: TRUE = "steps", FALSE = "silent").
+  "progress" prints a one-line generation summary plus a denoise
+  progress bar interactively, or a tick line every ~n/10 steps in
+  captured logs, so a long run is distinguishable from a hang without
+  per-step noise (#30).
+
 # diffuseR 0.1.0.9 (development)
 
 * The LTX-2.3 JIT block stack dequantizes NF4 weights through a

--- a/R/progress.R
+++ b/R/progress.R
@@ -1,0 +1,74 @@
+# progress.R
+#
+# Shared denoise-loop progress reporting (issue #30). Three verbosity
+# levels: "silent" (nothing), "progress" (a one-line generation summary
+# plus a progress bar interactively, or periodic step ticks in captured
+# logs), "steps" (the full per-phase chatter the generators already
+# emit). Logicals map for backwards compatibility: TRUE = "steps",
+# FALSE = "silent".
+
+#' Normalize a verbosity flag
+#'
+#' @param verbose Logical, or one of "silent", "progress", "steps".
+#'   TRUE maps to "steps" and FALSE to "silent".
+#'
+#' @return One of "silent", "progress", "steps".
+#'
+#' @keywords internal
+.verbosity <- function(verbose) {
+    if (isTRUE(verbose)) {
+        return("steps")
+    }
+    if (isFALSE(verbose)) {
+        return("silent")
+    }
+    if (is.character(verbose) && length(verbose) == 1L &&
+        verbose %in% c("silent", "progress", "steps")) {
+        return(verbose)
+    }
+    stop("'verbose' must be TRUE, FALSE, \"silent\", \"progress\", or \"steps\"",
+         call. = FALSE)
+}
+
+# Progress reporter for a denoise loop of n steps: returns tick(i, info)
+# and done(). At "progress", interactive sessions get a txtProgressBar
+# and non-interactive ones a tick line every ~n/10 steps, so captured
+# logs stay readable; label (if any) prints once before the loop. With
+# per_step = TRUE the caller supplies its own per-step detail through
+# tick(info = ) at the "steps" level instead of the bar/ticks.
+.denoise_progress <- function(n, label, verbose, per_step = FALSE) {
+    level <- .verbosity(verbose)
+    if (level == "silent") {
+        return(list(tick = function(i, info = NULL) invisible(NULL),
+                    done = function() invisible(NULL)))
+    }
+    if (level == "progress" && !is.null(label) && nzchar(label)) {
+        message(label)
+    }
+    stepwise <- level == "steps" && per_step
+    use_bar <- interactive() && !stepwise
+    pb <- if (use_bar) {
+        utils::txtProgressBar(min = 0, max = n, style = 3)
+    } else {
+        NULL
+    }
+    every <- max(1L, as.integer(ceiling(n / 10)))
+    tick <- function(i, info = NULL) {
+        if (stepwise) {
+            message(sprintf("  step %d/%d%s", i, n,
+                            if (is.null(info)) "" else paste0(" ", info)))
+        } else if (use_bar) {
+            utils::setTxtProgressBar(pb, i)
+        } else if (i %% every == 0L || i == n) {
+            message(sprintf("  step %d/%d", i, n))
+        }
+        invisible(NULL)
+    }
+    done <- function() {
+        if (use_bar) {
+            close(pb)
+        }
+        invisible(NULL)
+    }
+    list(tick = tick, done = done)
+}

--- a/R/progress.R
+++ b/R/progress.R
@@ -56,7 +56,7 @@
     tick <- function(i, info = NULL) {
         if (stepwise) {
             message(sprintf("  step %d/%d%s", i, n,
-                            if (is.null(info)) "" else paste0(" ", info)))
+                    if (is.null(info)) "" else paste0(" ", info)))
         } else if (use_bar) {
             utils::setTxtProgressBar(pb, i)
         } else if (i %% every == 0L || i == n) {

--- a/R/txt2img_flux.R
+++ b/R/txt2img_flux.R
@@ -219,11 +219,7 @@ flux_load_pipeline <- function(model_dir = NULL, device = "cuda",
                           compute_dtype, chunk_size = NULL, verbose = TRUE) {
     timesteps <- as.numeric(schedule$timesteps$cpu())
     n <- length(timesteps)
-    pb <- if (verbose) {
-        utils::txtProgressBar(min = 0, max = n, style = 3)
-    } else {
-        NULL
-    }
+    pb <- .denoise_progress(n, NULL, verbose)
     f32 <- torch::torch_float32()
 
     torch::with_no_grad({
@@ -249,14 +245,10 @@ flux_load_pipeline <- function(model_dir = NULL, device = "cuda",
             latents <- step$prev_sample
             schedule <- step$schedule
             rm(noise_pred, step)
-            if (!is.null(pb)) {
-                utils::setTxtProgressBar(pb, i)
-            }
+            pb$tick(i)
         }
     })
-    if (!is.null(pb)) {
-        close(pb)
-    }
+    pb$done()
     latents
 }
 
@@ -280,7 +272,10 @@ flux_load_pipeline <- function(model_dir = NULL, device = "cuda",
 #'   embeddings (skip the text encoders).
 #' @param save_file Logical. Write a PNG.
 #' @param filename Output path (default derived from the prompt).
-#' @param verbose Logical.
+#' @param verbose Logical, or one of "silent", "progress", "steps".
+#'   TRUE = "steps" (full per-phase chatter), FALSE = "silent".
+#'   "progress" prints a one-line generation summary plus a denoise
+#'   progress bar (interactive) or periodic step ticks (captured logs).
 #' @param ... Passed to \code{\link{flux_load_pipeline}} when
 #'   \code{pipeline} is NULL.
 #'
@@ -294,6 +289,12 @@ txt2img_flux <- function(prompt, pipeline = NULL, width = 1024L,
                          prompt_embeds = NULL, pooled_prompt_embeds = NULL,
                          save_file = TRUE, filename = NULL, verbose = TRUE,
                          ...) {
+    level <- .verbosity(verbose)
+    verbose <- level == "steps"
+    if (level != "silent") {
+        message(sprintf("FLUX.1 schnell: %dx%d, %d steps", as.integer(width),
+                        as.integer(height), as.integer(num_inference_steps)))
+    }
     if (is.null(pipeline)) {
         pipeline <- flux_load_pipeline(..., verbose = verbose)
     }
@@ -387,7 +388,7 @@ txt2img_flux <- function(prompt, pipeline = NULL, width = 1024L,
     latents <- .flux_denoise(
                              transformer, latents, sched, prompt_embeds,
                              pooled_prompt_embeds, rope, compute_dtype,
-                             chunk_size = pipeline$attn_chunk, verbose = verbose
+                             chunk_size = pipeline$attn_chunk, verbose = level
     )
     offload(pipeline$transformer)
     ltx23_release_dequant_buffers()

--- a/R/txt2img_flux2.R
+++ b/R/txt2img_flux2.R
@@ -147,11 +147,7 @@ flux2_load_pipeline <- function(model_dir = NULL, device = "cuda",
                            chunk_size = NULL, verbose = TRUE) {
     timesteps <- as.numeric(schedule$timesteps$cpu())
     n <- length(timesteps)
-    pb <- if (verbose) {
-        utils::txtProgressBar(min = 0, max = n, style = 3)
-    } else {
-        NULL
-    }
+    pb <- .denoise_progress(n, NULL, verbose)
     f32 <- torch::torch_float32()
 
     torch::with_no_grad({
@@ -174,14 +170,10 @@ flux2_load_pipeline <- function(model_dir = NULL, device = "cuda",
             latents <- step$prev_sample
             schedule <- step$schedule
             rm(noise_pred, step)
-            if (!is.null(pb)) {
-                utils::setTxtProgressBar(pb, i)
-            }
+            pb$tick(i)
         }
     })
-    if (!is.null(pb)) {
-        close(pb)
-    }
+    pb$done()
     latents
 }
 
@@ -205,7 +197,10 @@ flux2_load_pipeline <- function(model_dir = NULL, device = "cuda",
 #' @param prompt_embeds Optional precomputed [B, S, 7680] embeddings.
 #' @param save_file Logical. Write a PNG.
 #' @param filename Output path (default derived from the prompt).
-#' @param verbose Logical.
+#' @param verbose Logical, or one of "silent", "progress", "steps".
+#'   TRUE = "steps" (full per-phase chatter), FALSE = "silent".
+#'   "progress" prints a one-line generation summary plus a denoise
+#'   progress bar (interactive) or periodic step ticks (captured logs).
 #' @param ... Passed to \code{\link{flux2_load_pipeline}} when
 #'   \code{pipeline} is NULL.
 #'
@@ -218,6 +213,12 @@ txt2img_flux2 <- function(prompt, pipeline = NULL, width = 1024L,
                           max_sequence_length = 512L, seed = NULL,
                           prompt_embeds = NULL, save_file = TRUE,
                           filename = NULL, verbose = TRUE, ...) {
+    level <- .verbosity(verbose)
+    verbose <- level == "steps"
+    if (level != "silent") {
+        message(sprintf("FLUX.2 klein: %dx%d, %d steps", as.integer(width),
+                        as.integer(height), as.integer(num_inference_steps)))
+    }
     if (is.null(pipeline)) {
         pipeline <- flux2_load_pipeline(..., verbose = verbose)
     }
@@ -311,7 +312,7 @@ txt2img_flux2 <- function(prompt, pipeline = NULL, width = 1024L,
     latents <- .flux2_denoise(
                               transformer, latents, sched, prompt_embeds, rope,
                               compute_dtype, chunk_size = pipeline$attn_chunk,
-                              verbose = verbose
+                              verbose = level
     )
     if (isTRUE(pipeline$fp8_resident) && phase_offload) {
         .flux_fp8_to_device(pipeline$transformer, "cpu")

--- a/R/txt2img_zimage.R
+++ b/R/txt2img_zimage.R
@@ -175,11 +175,7 @@ zimage_load_pipeline <- function(model_dir = NULL, device = "cuda",
                             compute_dtype, chunk_size = NULL, verbose = TRUE) {
     timesteps <- as.numeric(schedule$timesteps$cpu())
     n <- length(timesteps)
-    pb <- if (verbose) {
-        utils::txtProgressBar(min = 0, max = n, style = 3)
-    } else {
-        NULL
-    }
+    pb <- .denoise_progress(n, NULL, verbose)
     f32 <- torch::torch_float32()
 
     torch::with_no_grad({
@@ -198,14 +194,10 @@ zimage_load_pipeline <- function(model_dir = NULL, device = "cuda",
             latents <- step$prev_sample
             schedule <- step$schedule
             rm(out, noise_pred, step)
-            if (!is.null(pb)) {
-                utils::setTxtProgressBar(pb, i)
-            }
+            pb$tick(i)
         }
     })
-    if (!is.null(pb)) {
-        close(pb)
-    }
+    pb$done()
     latents
 }
 
@@ -230,7 +222,10 @@ zimage_load_pipeline <- function(model_dir = NULL, device = "cuda",
 #'   embeddings (valid tokens only).
 #' @param save_file Logical. Write a PNG.
 #' @param filename Output path (default derived from the prompt).
-#' @param verbose Logical.
+#' @param verbose Logical, or one of "silent", "progress", "steps".
+#'   TRUE = "steps" (full per-phase chatter), FALSE = "silent".
+#'   "progress" prints a one-line generation summary plus a denoise
+#'   progress bar (interactive) or periodic step ticks (captured logs).
 #' @param ... Passed to \code{\link{zimage_load_pipeline}} when
 #'   \code{pipeline} is NULL.
 #'
@@ -243,6 +238,12 @@ txt2img_zimage <- function(prompt, pipeline = NULL, width = 1024L,
                            max_sequence_length = 512L, seed = NULL,
                            prompt_embeds = NULL, save_file = TRUE,
                            filename = NULL, verbose = TRUE, ...) {
+    level <- .verbosity(verbose)
+    verbose <- level == "steps"
+    if (level != "silent") {
+        message(sprintf("Z-Image Turbo: %dx%d, %d steps", as.integer(width),
+                        as.integer(height), as.integer(num_inference_steps)))
+    }
     if (is.null(pipeline)) {
         pipeline <- zimage_load_pipeline(..., verbose = verbose)
     }
@@ -323,7 +324,7 @@ txt2img_zimage <- function(prompt, pipeline = NULL, width = 1024L,
     latents <- .zimage_denoise(
                                transformer, latents, sched, prompt_embeds,
                                compute_dtype, chunk_size = pipeline$attn_chunk,
-                               verbose = verbose
+                               verbose = level
     )
     if (isTRUE(pipeline$fp8_resident) && phase_offload) {
         .flux_fp8_to_device(pipeline$transformer, "cpu")

--- a/R/txt2vid_ltx23.R
+++ b/R/txt2vid_ltx23.R
@@ -117,6 +117,11 @@ ltx23_unpack_audio_latents <- function(latents, num_mel_bins) {
 
     n_steps <- length(sigmas) - 1L
     scale_mult <- transformer$timestep_scale_multiplier
+    pb <- .denoise_progress(
+                            n_steps,
+                            if (nzchar(stage)) sprintf("%sdenoise: %d steps", stage, n_steps) else NULL,
+                            verbose, per_step = TRUE
+    )
     step_t0 <- Sys.time()
     torch::with_no_grad({
         for (i in seq_len(n_steps)) {
@@ -166,14 +171,12 @@ ltx23_unpack_audio_latents <- function(latents, num_mel_bins) {
             }
             rm(out)
             gc(verbose = FALSE)
-            if (verbose) {
-                message(sprintf("  %sstep %d/%d (sigma %.4f, %.1fs)",
-                                stage, i, n_steps, sigma,
-                                as.numeric(difftime(Sys.time(), step_t0, units = "secs"))))
-                step_t0 <- Sys.time()
-            }
+            pb$tick(i, sprintf("%s(sigma %.4f, %.1fs)", stage, sigma,
+                as.numeric(difftime(Sys.time(), step_t0, units = "secs"))))
+            step_t0 <- Sys.time()
         }
     })
+    pb$done()
     list(latents = latents, audio_latents = audio_latents)
 }
 
@@ -431,7 +434,11 @@ ltx23_load_pipeline <- function(checkpoint_path, device = "cuda",
 #'   clean, frozen audio latents that the video attends to while
 #'   denoising, and the original samples are muxed into the output
 #'   (audio decoding is skipped).
-#' @param verbose Logical.
+#' @param verbose Logical, or one of "silent", "progress", "steps".
+#'   TRUE = "steps" (full per-phase chatter, per-step sigma/timing
+#'   lines), FALSE = "silent". "progress" prints a one-line generation
+#'   summary plus a denoise progress bar (interactive) or periodic
+#'   step ticks (captured logs).
 #'
 #' @return Invisibly, a list with \code{video} (array
 #'   [frames, height, width, 3] in [0, 1]), \code{audio} (matrix
@@ -451,6 +458,13 @@ txt2vid_ltx2 <- function(prompt, pipeline, text_encoder = NULL,
                          image = NULL, condition_video = NULL,
                          conditioning_frames = 9L, cond_noise_scale = 0,
                          audio = NULL, verbose = TRUE) {
+    level <- .verbosity(verbose)
+    verbose <- level == "steps"
+    if (level != "silent") {
+        message(sprintf("LTX-2.3: %d frames @ %dx%d, %d steps%s",
+                        num_frames, width, height, length(sigmas) - 1L,
+                        if (two_stage) " (two-stage)" else ""))
+    }
     stopifnot(inherits(pipeline, "ltx23_pipeline"))
     if (guidance_scale != 1) {
         stop("Only guidance_scale = 1 is supported (distilled checkpoints).")
@@ -681,7 +695,7 @@ txt2vid_ltx2 <- function(prompt, pipeline, text_encoder = NULL,
                                video_text_embeds, audio_text_embeds, text_mask,
                                latent_frames, s1_height, s1_width,
                                audio_num_frames, frame_rate,
-                               device, compute_dtype, verbose = verbose,
+                               device, compute_dtype, verbose = level,
                                stage = if (two_stage) "stage 1 " else "",
                                conditioning_mask = conditioning_mask,
                                audio_conditioned = audio_conditioned
@@ -740,7 +754,7 @@ txt2vid_ltx2 <- function(prompt, pipeline, text_encoder = NULL,
                                    video_text_embeds, audio_text_embeds, text_mask,
                                    latent_frames, latent_height, latent_width,
                                    audio_num_frames, frame_rate,
-                                   device, compute_dtype, verbose = verbose, stage = "stage 2 "
+                                   device, compute_dtype, verbose = level, stage = "stage 2 "
         )
         latents <- denoised$latents
         audio_latents <- denoised$audio_latents

--- a/R/txt2vid_ltx23.R
+++ b/R/txt2vid_ltx23.R
@@ -119,7 +119,11 @@ ltx23_unpack_audio_latents <- function(latents, num_mel_bins) {
     scale_mult <- transformer$timestep_scale_multiplier
     pb <- .denoise_progress(
                             n_steps,
-                            if (nzchar(stage)) sprintf("%sdenoise: %d steps", stage, n_steps) else NULL,
+        if (nzchar(stage)) {
+            sprintf("%sdenoise: %d steps", stage, n_steps)
+        } else {
+            NULL
+        },
                             verbose, per_step = TRUE
     )
     step_t0 <- Sys.time()
@@ -172,7 +176,7 @@ ltx23_unpack_audio_latents <- function(latents, num_mel_bins) {
             rm(out)
             gc(verbose = FALSE)
             pb$tick(i, sprintf("%s(sigma %.4f, %.1fs)", stage, sigma,
-                as.numeric(difftime(Sys.time(), step_t0, units = "secs"))))
+                               as.numeric(difftime(Sys.time(), step_t0, units = "secs"))))
             step_t0 <- Sys.time()
         }
     })
@@ -461,9 +465,9 @@ txt2vid_ltx2 <- function(prompt, pipeline, text_encoder = NULL,
     level <- .verbosity(verbose)
     verbose <- level == "steps"
     if (level != "silent") {
-        message(sprintf("LTX-2.3: %d frames @ %dx%d, %d steps%s",
-                        num_frames, width, height, length(sigmas) - 1L,
-                        if (two_stage) " (two-stage)" else ""))
+        message(sprintf("LTX-2.3: %d frames @ %dx%d, %d steps%s", num_frames,
+                        width, height, length(sigmas) - 1L,
+                if (two_stage) " (two-stage)" else ""))
     }
     stopifnot(inherits(pipeline, "ltx23_pipeline"))
     if (guidance_scale != 1) {

--- a/inst/tinytest/test_progress.R
+++ b/inst/tinytest/test_progress.R
@@ -1,0 +1,51 @@
+# .verbosity normalization and .denoise_progress output. These tests
+# run non-interactively, so the "progress" level takes the periodic
+# tick path (the txtProgressBar branch needs interactive()).
+
+verbosity <- diffuseR:::.verbosity
+progress <- diffuseR:::.denoise_progress
+
+expect_equal(verbosity(TRUE), "steps")
+expect_equal(verbosity(FALSE), "silent")
+expect_equal(verbosity("silent"), "silent")
+expect_equal(verbosity("progress"), "progress")
+expect_equal(verbosity("steps"), "steps")
+expect_error(verbosity("loud"))
+expect_error(verbosity(1))
+expect_error(verbosity(c("progress", "steps")))
+
+run_loop <- function(n, verbose, per_step = FALSE, label = NULL,
+                     info = NULL) {
+    capture.output({
+        pb <- progress(n, label, verbose, per_step = per_step)
+        for (i in seq_len(n)) {
+            pb$tick(i, info)
+        }
+        pb$done()
+    }, type = "message")
+}
+
+# silent: nothing at all
+expect_equal(length(run_loop(20, FALSE)), 0L)
+expect_equal(length(run_loop(20, "silent", label = "denoise: 20 steps")), 0L)
+
+# progress, non-interactive: label plus a tick every ceiling(n/10) steps
+out <- run_loop(20, "progress", label = "denoise: 20 steps")
+expect_equal(out[1], "denoise: 20 steps")
+expect_equal(out[-1], sprintf("  step %d/20", seq(2, 20, by = 2)))
+
+# the final step always ticks, even off-cadence
+out <- run_loop(7, "progress")
+expect_true("  step 7/7" %in% out)
+
+# steps with per_step: one line per step carrying the caller's info
+out <- run_loop(3, "steps", per_step = TRUE, info = "(sigma 0.9)")
+expect_equal(out, sprintf("  step %d/3 (sigma 0.9)", 1:3))
+
+# steps with per_step: label is progress-only, so it does not print
+out <- run_loop(3, "steps", per_step = TRUE, label = "stage 1")
+expect_equal(out, sprintf("  step %d/3", 1:3))
+
+# steps without per_step (flux-family loops): same ticks as progress
+out <- run_loop(20, TRUE)
+expect_equal(out, sprintf("  step %d/20", seq(2, 20, by = 2)))

--- a/man/dot-verbosity.Rd
+++ b/man/dot-verbosity.Rd
@@ -1,0 +1,18 @@
+% tinyrox says don't edit this manually, but it can't stop you!
+\name{.verbosity}
+\alias{.verbosity}
+\title{Normalize a verbosity flag}
+\usage{
+.verbosity(verbose)
+}
+\arguments{
+\item{verbose}{Logical, or one of "silent", "progress", "steps".
+TRUE maps to "steps" and FALSE to "silent".}
+}
+\value{
+One of "silent", "progress", "steps".
+}
+\description{
+Normalize a verbosity flag
+}
+\keyword{internal}

--- a/man/txt2img_flux.Rd
+++ b/man/txt2img_flux.Rd
@@ -26,7 +26,10 @@ a seed matches a Python diffusers run with a CPU generator.}
 
 \item{filename}{Output path (default derived from the prompt).}
 
-\item{verbose}{Logical.}
+\item{verbose}{Logical, or one of "silent", "progress", "steps".
+TRUE = "steps" (full per-phase chatter), FALSE = "silent".
+"progress" prints a one-line generation summary plus a denoise
+progress bar (interactive) or periodic step ticks (captured logs).}
 
 \item{...}{Passed to \code{\link{flux_load_pipeline}} when
 \code{pipeline} is NULL.}

--- a/man/txt2img_flux2.Rd
+++ b/man/txt2img_flux2.Rd
@@ -29,7 +29,10 @@ generator.}
 
 \item{filename}{Output path (default derived from the prompt).}
 
-\item{verbose}{Logical.}
+\item{verbose}{Logical, or one of "silent", "progress", "steps".
+TRUE = "steps" (full per-phase chatter), FALSE = "silent".
+"progress" prints a one-line generation summary plus a denoise
+progress bar (interactive) or periodic step ticks (captured logs).}
 
 \item{...}{Passed to \code{\link{flux2_load_pipeline}} when
 \code{pipeline} is NULL.}

--- a/man/txt2img_zimage.Rd
+++ b/man/txt2img_zimage.Rd
@@ -29,7 +29,10 @@ embeddings (valid tokens only).}
 
 \item{filename}{Output path (default derived from the prompt).}
 
-\item{verbose}{Logical.}
+\item{verbose}{Logical, or one of "silent", "progress", "steps".
+TRUE = "steps" (full per-phase chatter), FALSE = "silent".
+"progress" prints a one-line generation summary plus a denoise
+progress bar (interactive) or periodic step ticks (captured logs).}
 
 \item{...}{Passed to \code{\link{zimage_load_pipeline}} when
 \code{pipeline} is NULL.}

--- a/man/txt2vid_ltx2.Rd
+++ b/man/txt2vid_ltx2.Rd
@@ -87,7 +87,11 @@ clean, frozen audio latents that the video attends to while
 denoising, and the original samples are muxed into the output
 (audio decoding is skipped).}
 
-\item{verbose}{Logical.}
+\item{verbose}{Logical, or one of "silent", "progress", "steps".
+TRUE = "steps" (full per-phase chatter, per-step sigma/timing
+lines), FALSE = "silent". "progress" prints a one-line generation
+summary plus a denoise progress bar (interactive) or periodic
+step ticks (captured logs).}
 
 \item{text_encoder,tokenizer}{Gemma3 model and tokenizer (or paths;
 see \code{\link{load_gemma3_text_encoder}} and


### PR DESCRIPTION
Closes #30.

The samplers were all-or-nothing on `verbose`: TRUE floods a line per step (ltx23) or draws a `txtProgressBar` that garbles captured logs (flux/flux2/zimage); FALSE is dead silence for a generation that can run minutes, indistinguishable from a hang.

`verbose` now accepts `"silent"` / `"progress"` / `"steps"` on `txt2vid_ltx2()`, `txt2img_flux2()`, `txt2img_flux()`, and `txt2img_zimage()`. Logicals map for compatibility (TRUE = "steps", FALSE = "silent") and the defaults are unchanged, so existing callers see no behavior change.

At `"progress"`:
- the generator prints a one-line summary up front (`FLUX.2 klein: 1024x1024, 4 steps`, `LTX-2.3: 121 frames @ 768x512, 8 steps (two-stage)`), before any pipeline load;
- the new shared `.denoise_progress()` helper (base R, `R/progress.R`) drives the loop: `txtProgressBar` when `interactive()`, otherwise a tick line every ~n/10 steps so logs stay readable;
- loader/phase chatter stays at `"steps"`.

At `"steps"` the ltx23 loop keeps its per-step sigma/timing lines through the same helper (two-stage runs label each stage at "progress"). A bad `verbose` value errors before any model load.

16 tinytest assertions cover the flag normalization, tick cadence, final-step tick, per-step info lines, and silence.

Follow-up (xtx.api): `.tti_flux2()` and the stv path currently hardcode `verbose = FALSE`; switching them to `"progress"` is what gives the lc40 pipeline its sign of life.