### PR TITLE
Release 0.2.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: diffuseR
 Title: Functional Interface to Diffusion Models in R
-Version: 0.2.1.3
+Version: 0.2.2
 Authors@R: c(
     person("Troy", "Hernandez", email = "troy@cornball.ai", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0005-4248-604X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# diffuseR 0.2.1.3
+# diffuseR 0.2.2
 
 * Every precision `recommend()` can return is now reachable. `bf16` was
   advertised for flux1 at 24 GB and flux2/zimage at 16-24 GB while no
@@ -22,7 +22,6 @@
   License and FLUX.1-schnell is gated, so hosting would cover half the
   catalog and leave two models on a different workflow.
 
-# diffuseR 0.2.1.2
 
 * Model residency: `resident_load()`, `resident_activate()`,
   `resident_deactivate()`, `resident_generate()`, `resident_status()`
@@ -48,9 +47,7 @@
   cycle. FLUX.1 and LTX both have pinned sets larger than the card, so
   they exercise the refusal path rather than bulk onload.
 
-# diffuseR 0.2.1.1
-
-Addresses the CRAN review of the 0.2.0 submission.
+Addressing the CRAN review of the 0.2.0 submission:
 
 * Every exported `.Rd` with a `\usage` block now documents its return
   value: 50 `@return` tags added, chiefly to the `nn_module` generators

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,10 +1,27 @@
+## Resubmission
+
+This is a resubmission of 0.2.0. The four points raised in review are
+addressed:
+
+* Software names are single-quoted in the Description ('Python',
+  'Stable Diffusion', 'Hugging Face', with a URL for the last).
+* The doubled spaces are gone. They came from trailing whitespace on
+  every continuation line, which DCF folding turned into two spaces.
+* \value is now present on all 50 exported .Rd files that were missing
+  it, describing the class and meaning of the result. (Topic pages that
+  document no function, and therefore have no \usage, do not have one.)
+* 14 of the 23 \dontrun{} examples were unwrapped and now run during
+  check; they were also rewritten to be self-contained rather than
+  referring to objects that were never defined. The 10 that remain are
+  listed below with the reason for each.
+
 ## Test environments
 
 * Ubuntu 24.04 (local), R 4.6.x: R CMD check --as-cran
 * Windows 10, R 4.6.0 (full test suite against installed torch backend)
-* Windows 10, R-devel (2026-07-21 r90286), torch installed without its
-  lantern backend (tests skip gracefully)
-* win-builder, R-devel (2026-07-22 r90289)
+* Windows 10, R-devel, torch installed without its lantern backend
+  (tests skip gracefully)
+* win-builder, R-devel
 
 ## R CMD check results
 
@@ -20,14 +37,8 @@ package.
 
 ## Notes for the reviewers
 
-* On the previous submission we were asked to replace `\dontrun{}`
-  with `\donttest{}`. We unwrapped 14 of the 23 examples so they now
-  run during check (device/profile policy helpers, both schedulers,
-  the VRAM helpers, `save_image()`, `save_video()` frame output, and a
-  small `vae_decoder_native()`), and rewrote them to be self-contained
-  rather than referencing undefined objects. Nine remain under
-  `\dontrun{}` because they cannot execute anywhere without model
-  weights on disk:
+* Ten examples remain under `\dontrun{}`. Each needs multi-GB model
+  weights on disk, so none can execute on a check machine:
 
   - `download_model()`, `download_component()` - network downloads of
     multi-GB weights.
@@ -37,12 +48,20 @@ package.
     generation; needs the weights and minutes of compute.
   - `ltx23_open_checkpoint()` - needs a ~20 GB LTX-2.3 checkpoint the
     user downloads under Lightricks' own license.
+  - `resident_load()` - loads a full pipeline onto a GPU.
   - `load_decoder_weights()` in the `vae_decoder_native()` page -
     needs a checkpoint file. The rest of that example runs.
 
   `\donttest{}` would not help for these: CRAN runs `\donttest{}`
-  examples, and each of these would either attempt a large download or
-  fail on a missing file.
+  examples, and each would either attempt a large download or fail on a
+  missing file.
+
+* `save_video()`'s MP4 example is deliberately shown as a comment
+  rather than run. Both encoder backends hand off to an ffmpeg process
+  that inherits the session's stdin, which `R CMD check --as-cran` uses
+  to feed the example script to R, so a live call consumes part of the
+  script and later examples parse short. The frame-writing path is
+  exercised live instead.
 
 * Model weights are never bundled and never downloaded without
   consent: every download function prompts interactively with the


### PR DESCRIPTION
Release bump for the CRAN resubmission of 0.2.0.

The three unreleased dev markers (0.2.1.1, 0.2.1.2, 0.2.1.3) are
consolidated under a single `0.2.2` NEWS heading — CRAN sees one release,
not three GitHub-only deltas.

`cran-comments.md` gains a **Resubmission** section answering the four
review points directly, and the `\dontrun{}` inventory is corrected from 9
to 10 (`resident_load()` was added since). It also explains why
`save_video()`'s MP4 example is a comment rather than a live call: both
encoder backends hand off to an ffmpeg process that inherits the session's
stdin, which `--as-cran` uses to feed the example script to R.

## Check results

| environment | result |
|---|---|
| Ubuntu 24.04, R 4.6.x, `--as-cran` | 0 errors, 0 warnings, 2 NOTEs |
| Windows 10, R-devel, `--as-cran` | 0 errors, 0 warnings, **1 NOTE** |
| Windows 10, R 4.6.0, `--as-cran` | 0 errors, 0 warnings, **1 NOTE** |

The single NOTE on Windows is "New submission". The extra Linux NOTE is
torch's own load hook failing in check subprocesses that run without
`utils` attached (`could not find function packageName`); it does not
reproduce on either Windows check, which is what `cran-comments.md` claims.

Test suite: 1097 assertions pass with the safetensors dev build installed,
1069 with stock CRAN capabilities simulated (the fp8 blocks skip).