### PR TITLE
Survive torch installed without lantern

### DIFF
--- a/R/vram.R
+++ b/R/vram.R
@@ -58,8 +58,13 @@ is_blackwell_gpu <- function() {
         return(mb / 1024)
     }
 
-    # Fallback: check if CUDA available but can't determine VRAM
-    if (torch::cuda_is_available()) {
+    # Fallback: check if CUDA available but can't determine VRAM.
+    # cuda_is_available() ERRORS (not FALSE) when torch is installed
+    # without its lantern binaries - fresh installs, win-builder, CRAN -
+    # and this branch is exactly where those machines land, since they
+    # have no nvidia-smi either. Probe soft, same as is_blackwell_gpu().
+    if (isTRUE(tryCatch(torch::cuda_is_available(),
+                        error = function(e) FALSE))) {
         # Conservative estimate - assume 8GB if we can't detect
         message("Could not detect VRAM via nvidia-smi; assuming 8 GB.")
         return(8)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -18,9 +18,11 @@ addressed:
 ## Test environments
 
 * Ubuntu 24.04 (local), R 4.6.x: R CMD check --as-cran
-* Windows 10, R 4.6.0 (full test suite against installed torch backend)
-* Windows 10, R-devel, torch installed without its lantern backend
-  (tests skip gracefully)
+* Windows 10, R 4.6.0 and R-devel: R CMD check --as-cran, with torch's
+  lantern backend installed (so the full suite runs)
+* Ubuntu, with lantern deliberately absent, to exercise the path
+  win-builder and CRAN take: examples and tests skip gracefully rather
+  than erroring
 * win-builder, R-devel
 
 ## R CMD check results
@@ -71,4 +73,6 @@ package.
   under tools::R_user_dir("diffuseR", "data").
 * torch is in Imports; all tests, examples, and vignette code degrade
   gracefully when torch's backend (lantern) is not installed, as on
-  win-builder.
+  win-builder. Note that `torch::cuda_is_available()` raises an error
+  rather than returning FALSE in that state, so the package probes it
+  through `tryCatch()` everywhere it is reachable without a GPU.

--- a/inst/tinytest/test_resident.R
+++ b/inst/tinytest/test_resident.R
@@ -19,7 +19,18 @@ fake_pipeline <- function() {
               class = "test_pipeline")
 }
 
+# Everything from here to the "state machine" section builds real
+# nn_modules or torch dtypes, so it needs a working lantern. torch
+# installed WITHOUT its lantern binaries is the normal state on
+# win-builder and CRAN, and there `torch::nn_linear()` errors rather
+# than returning. The state-machine sections below are pure R and run
+# everywhere.
+have_torch <- requireNamespace("torch", quietly = TRUE) &&
+    torch::torch_is_installed()
+
 # --- component discovery ----------------------------------------------------------
+
+if (have_torch) {
 
 pipe <- fake_pipeline()
 comps <- diffuseR:::.resident_components(pipe)
@@ -39,6 +50,8 @@ expect_equal(diffuseR:::.dtype_bytes(torch::torch_float16()), 2)
 expect_equal(diffuseR:::.dtype_bytes(torch::torch_bfloat16()), 2)
 expect_equal(diffuseR:::.dtype_bytes(torch::torch_uint8()), 1)
 expect_equal(diffuseR:::.dtype_bytes(torch::torch_int64()), 8)
+
+} # end have_torch
 
 # --- byte formatting --------------------------------------------------------------
 
@@ -140,7 +153,7 @@ expect_equal(resident_status(u)$state, "unloaded")
 
 # --- CUDA round trip --------------------------------------------------------------
 
-if (at_home() && torch::cuda_is_available()) {
+if (have_torch && at_home() && torch::cuda_is_available()) {
     pipe <- fake_pipeline()
     staging <- diffuseR:::.resident_pin(pipe, verbose = FALSE)
     expect_equal(sort(names(staging)),


### PR DESCRIPTION
win-builder R-devel failed 0.2.2 with two errors, both *"Lantern is not
loaded"*: the auto-detect branch of the `auto_devices()` example, and
`test_resident.R`.

## One line caused both

`.detect_vram()` falls back to `torch::cuda_is_available()` when nvidia-smi
is absent — and that call **errors rather than returning FALSE** when torch
is installed without its lantern binaries. That is exactly the state
win-builder and CRAN are in, and exactly the branch they land in, since
those machines have no nvidia-smi either.

`is_blackwell_gpu()` has guarded this since it was written, and its comment
says why. `.detect_vram()` never did. It now probes through `tryCatch()` the
same way, which fixes `auto_devices()`, `sdxl_memory_profile()` and
`recommend()` together, since all three route through it.

`test_resident.R` built real `nn_module`s at top level with no lantern guard.
The torch-dependent sections (component discovery, dtype table, CUDA round
trip) now sit behind one; the pure-R sections — state machine, transition
guards, status, print, unload — still run on CRAN, where they are the parts
that *can* run.

## Why the local Windows check passed

| | `torch_is_installed()` | `cuda_is_available()` |
|---|---|---|
| windows-hr, R-devel | TRUE | returns `FALSE` cleanly |
| win-builder, R-devel | FALSE | **errors** |

windows-hr has lantern installed on both R 4.6.0 and R-devel, so the
fallback behaved. `cran-comments.md` claimed that machine ran "without its
lantern backend" — untrue, and corrected here. It is not a proxy for CRAN on
this axis.

## Reproducible locally now, which is the durable fix

```sh
TORCH_HOME=$(mktemp -d) Rscript --vanilla -e \
  'library(diffuseR); library(tinytest); run_test_dir("inst/tinytest")'
```

An empty `TORCH_HOME` makes `torch_is_installed()` FALSE and
`cuda_is_available()` throw, matching win-builder exactly. Under it the five
previously-failing examples pass and 271 assertions run green, the rest
skipping as intended.