### PR TITLE
Make the fits check testable instead of GPU-dependent

### DIFF
--- a/R/resident.R
+++ b/R/resident.R
@@ -310,13 +310,20 @@ resident_load <- function(model = c("flux2", "flux1", "zimage", "ltx"),
 #' actual problem, which is that this model does not fit this card.
 #'
 #' @param res A resident handle.
+#' @param free_gb Free VRAM in GB. NULL measures it. Pass a value to
+#'   make the decision deterministic: with no GPU the measurement is 0,
+#'   which means "cannot tell" and never refuses, so a test that wants
+#'   the refusal has to state the budget rather than depend on the
+#'   machine having a card.
 #'
 #' @return Invisibly TRUE, or an error naming both figures.
 #'
 #' @keywords internal
-.resident_check_fits <- function(res) {
-    free_gb <- tryCatch(.detect_vram(use_free = TRUE),
-                        error = function(e) NA_real_)
+.resident_check_fits <- function(res, free_gb = NULL) {
+    if (is.null(free_gb)) {
+        free_gb <- tryCatch(.detect_vram(use_free = TRUE),
+                            error = function(e) NA_real_)
+    }
     need_gb <- res$pinned_bytes / 1024^3
     if (!is.na(free_gb) && free_gb > 0 && need_gb > free_gb) {
         stop(sprintf(paste0("%s needs %.2f GB resident but only %.2f GB of ",

--- a/inst/tinytest/test_resident.R
+++ b/inst/tinytest/test_resident.R
@@ -113,11 +113,26 @@ expect_error(resident_generate(mk("broken"), "a cat"), pattern = "broken")
 
 # Named figures beat a libtorch allocator error: FLUX.1's 15.73 GB pinned
 # set does not fit a 15.47 GiB card, and the message should say so.
-huge <- mk("inactive", pinned_bytes = 1e15)
-expect_error(diffuseR:::.resident_check_fits(huge), pattern = "needs")
-expect_error(diffuseR:::.resident_check_fits(huge), pattern = "phase_offload")
+#
+# free_gb is stated rather than measured. Measured, it is 0 on any
+# machine without a GPU -- which means "cannot tell", so the check
+# declines to refuse and these assertions saw no error. That is correct
+# behaviour and a broken test: it passed on the GPU box and failed CI on
+# both ubuntu-latest and macos-latest.
+huge <- mk("inactive", pinned_bytes = 16 * 1024^3)
+expect_error(diffuseR:::.resident_check_fits(huge, free_gb = 15.47),
+             pattern = "needs")
+expect_error(diffuseR:::.resident_check_fits(huge, free_gb = 15.47),
+             pattern = "phase_offload")
+# A set that fits is not refused.
+expect_true(diffuseR:::.resident_check_fits(huge, free_gb = 24))
 # A trivial set is never refused.
-expect_true(diffuseR:::.resident_check_fits(mk("inactive", pinned_bytes = 0)))
+expect_true(diffuseR:::.resident_check_fits(mk("inactive", pinned_bytes = 0),
+                                            free_gb = 15.47))
+# Undetectable VRAM (0, as on a GPU-less machine) must not block: the
+# check refuses only when it can prove the set does not fit.
+expect_true(diffuseR:::.resident_check_fits(huge, free_gb = 0))
+expect_true(diffuseR:::.resident_check_fits(huge, free_gb = NA_real_))
 
 # --- status and print -------------------------------------------------------------
 

--- a/man/dot-resident_check_fits.Rd
+++ b/man/dot-resident_check_fits.Rd
@@ -3,10 +3,16 @@
 \alias{.resident_check_fits}
 \title{Refuse a bulk activation that cannot fit}
 \usage{
-.resident_check_fits(res)
+.resident_check_fits(res, free_gb = NULL)
 }
 \arguments{
 \item{res}{A resident handle.}
+
+\item{free_gb}{Free VRAM in GB. NULL measures it. Pass a value to
+make the decision deterministic: with no GPU the measurement is 0,
+which means "cannot tell" and never refuses, so a test that wants
+the refusal has to state the budget rather than depend on the
+machine having a card.}
 }
 \value{
 Invisibly TRUE, or an error naming both figures.


### PR DESCRIPTION
CI has been red on every run since #47, on both `ubuntu-latest` and
`macos-latest`:

```
FAILED[xcpt]: test_resident.R<117>
 call| expect_error(diffuseR:::.resident_check_fits(huge), pattern = "needs")
 diff| No error
```

The function is right; the test was wrong. `.resident_check_fits()` refuses a
bulk activation only when it can *prove* the set does not fit — with no GPU
the measurement is 0, meaning "cannot tell", so it declines to block. The
test asserted the refusal unconditionally, so it passed on the GPU box and
failed everywhere else.

`free_gb` is now an argument (NULL measures, as before). The test states a
budget rather than depending on the machine having a card, and covers cases
it never did: a set that fits is allowed, and an undetectable `0`/`NA` does
not block.

This is the same class as the win-builder lantern failure and the Windows
`st_caps` failure — an assertion that **read** the environment instead of
**stating** it. Verified against all three environments this package has to
survive:

| environment | test_resident.R |
|---|---|
| GPU present | 58 pass |
| `CUDA_VISIBLE_DEVICES=""` (CI) | 43 pass |
| empty `TORCH_HOME` (win-builder) | 33 pass |

Full suite CI-style (`CUDA_VISIBLE_DEVICES=""`): 1070 assertions pass.

The 2 vignette WARNINGs in the CI log (`inst/doc` absent) predate this work
and are tolerated by r-ci; the ERROR was the failure.