### PR TITLE
Drop LazyData: there is no data directory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ License: Apache License (>= 2)
 URL: https://github.com/cornball-ai/diffuseR
 BugReports: https://github.com/cornball-ai/diffuseR/issues
 Encoding: UTF-8
-LazyData: true
 Imports:
     torch,
     jsonlite,


### PR DESCRIPTION
`R CMD build` has been printing *"Omitted 'LazyData' from DESCRIPTION"* on
every build. The package ships no `data/` directory, so the field is dead
metadata that the build strips anyway, and CRAN NOTEs it on some checks.

Verified the message is gone and the field is absent from the built tarball.
`R CMD check --as-cran`: 0 errors, 0 warnings, 2 NOTEs (unchanged).