### PR TITLE
recommend(): 0.5 GB tolerance so nameplate min_vram tiers are reachable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: diffuseR
 Title: Functional Interface to Diffusion Models in R
-Version: 0.2.2.1
+Version: 0.2.2.2
 Authors@R: c(
     person("Troy", "Hernandez", email = "troy@cornball.ai", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0005-4248-604X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# diffuseR 0.2.2.2
+
+* `recommend()` tier selection now applies a 0.5 GB tolerance to the
+  `min_vram` thresholds (#56). The thresholds are nameplate card sizes,
+  but detection reports free VRAM and no card reports its nameplate as
+  free, so every nameplate-valued tier (the flux-family 8 GB tiers, the
+  SDXL 12 GB tier, the flux2 bf16 16 GB tier) was unreachable on
+  exactly the card it targets and silently dropped to the CPU tier.
+
 # diffuseR 0.2.2.1
 
 * `txt2img()` and `img2img()` now `match.arg()` their `model_name`, so

--- a/R/recommend.R
+++ b/R/recommend.R
@@ -93,7 +93,12 @@ recommend <- function(model = c("sd21", "sdxl", "flux1", "flux2", "zimage",
     chosen <- NULL
     want <- NULL # first VRAM-eligible tier blocked by a missing read cap
     for (tier in tiers) {
-        if (vram_gb < tier$min_vram) {
+        # min_vram values are nameplate card sizes (8, 12, 16...), but
+        # vram_gb is FREE VRAM, and no card reports its nameplate as
+        # free (an 8 GB card shows ~7.5-7.9). Without the 0.5 GB
+        # tolerance every nameplate-valued tier is unreachable on
+        # exactly the card it targets (#56).
+        if (vram_gb < tier$min_vram - 0.5) {
             next
         }
         need <- tier$needs

--- a/inst/tinytest/test_recommend.R
+++ b/inst/tinytest/test_recommend.R
@@ -19,6 +19,17 @@ expect_true(all(c("precision", "devices", "offload", "max_pixels",
   names(r)))
 expect_true(is.integer(r$max_pixels) || is.numeric(r$max_pixels))
 
+# --- nameplate tiers reachable on their own cards (#56) --------------------------
+
+# min_vram thresholds are nameplate sizes, but detection reports free
+# VRAM: a real 8 GB card shows ~7.5-7.9 free. The 0.5 GB tolerance keeps
+# the 8 GB tier selectable there; below the tolerance drops to CPU.
+r8 <- recommend("flux2", vram_gb = 7.6, st_caps = cran)
+expect_equal(r8$devices$transformer, "cuda")
+expect_equal(r8$precision, "nf4")
+r7 <- recommend("flux2", vram_gb = 7.4, st_caps = cran)
+expect_true(all(unlist(r7$devices) == "cpu"))
+
 # --- floors: nf4 for the quantized families, fp16 for SD -------------------------
 
 # No GPU: everything runs on CPU at its floor precision, no fork nag.


### PR DESCRIPTION
Fixes #56.

The tier table's `min_vram` values are nameplate card sizes (8, 12, 16...), but `recommend()` compares them against detected FREE VRAM, and no card reports its nameplate as free: a real 8 GB card shows ~7.5-7.9 GB. So every nameplate-valued tier (the flux-family 8 GB nf4 tiers, SDXL's 12 GB full-GPU tier, flux2's 16 GB bf16 tier) was unreachable on exactly the card it targets, silently dropping to the CPU tier.

One-line fix, option 2 from the issue: a 0.5 GB tolerance in the single comparison, keeping the tier table's readable nameplate numbers. The CPU tier (min_vram = 0) is unaffected. Tests pin the boundary: `vram_gb = 7.6` selects the flux2 8 GB GPU tier, `7.4` drops to CPU; all 92 existing recommend tests unchanged.